### PR TITLE
List transitive version requirements for target

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation
 
 You don't need to include `bundler-stats` in your Gemfile, just
 `gem install bundler-stats`. Unless you wanted to build automation around its
-usage, in which case, add it to your Gemfile instead. 
+usage, in which case, add it to your Gemfile instead.
 
 
 Usage
@@ -27,10 +27,11 @@ Usage
 
     > bundle-stats help
       Commands:
-        bundle-stats help [COMMAND]  # Describe available commands or one specific command
-        bundle-stats show TARGET     # Prints the dependency tree for a single gem in your Gemfile
-        bundle-stats stats           # Displays basic stats about the gems in your Gemfile
-        bundle-stats version         # Prints the bundler-stats version
+        bundle-stats help [COMMAND]   # Describe available commands or one specific command
+        bundle-stats show TARGET      # Prints the dependency tree for a single gem in your Gemfile
+        bundle-stats stats            # Displays basic stats about the gems in your Gemfile
+        bundle-stats version          # Prints the bundler-stats version
+        bundle-stats versions TARGET  # Shows versions requirements for target in other dependencies
 
 The most obvious thing to do is run the command by itself, which should help identify problem areas:
 

--- a/lib/bundler/stats/calculator.rb
+++ b/lib/bundler/stats/calculator.rb
@@ -29,6 +29,12 @@ module Bundler
         })
       end
 
+      def versions(target)
+        @tree.version_requirements(target).merge({
+          potential_removals: @remover.potential_removals(target)
+        })
+      end
+
       def stats
         { summary: summary,
           gems: gem_stats

--- a/lib/bundler/stats/cli.rb
+++ b/lib/bundler/stats/cli.rb
@@ -38,7 +38,7 @@ module Bundler
         end
       end
 
-      desc 'Versions TARGET', 'Prints the dependency tree for a single gem in your Gemfile'
+      desc 'versions TARGET', 'Shows versions requirements for target in other dependencies'
       method_option :format, aliases: "-f", description: "Output format, either JSON or text"
       method_option :nofollow, description: "A comma delimited list of dependencies not to follow."
       def versions(target)

--- a/lib/bundler/stats/cli.rb
+++ b/lib/bundler/stats/cli.rb
@@ -38,6 +38,20 @@ module Bundler
         end
       end
 
+      desc 'Versions TARGET', 'Prints the dependency tree for a single gem in your Gemfile'
+      method_option :format, aliases: "-f", description: "Output format, either JSON or text"
+      method_option :nofollow, description: "A comma delimited list of dependencies not to follow."
+      def versions(target)
+        calculator = build_calculator(options)
+        stats = calculator.versions(target)
+
+        if options[:format] =~ /json/i
+          say JSON.pretty_generate(stats)
+        else
+          draw_versions(stats, target)
+        end
+      end
+
       desc 'version', 'Prints the bundler-stats version'
       def version
         say "bundler-stats #{VERSION}"
@@ -67,6 +81,20 @@ module Bundler
         say "depended upon by (#{stats[:top_level_dependencies].count}) | #{stats[:top_level_dependencies].values.map(&:name).join(', ')}\n"
         say "depends on (#{stats[:transitive_dependencies].count})      | #{stats[:transitive_dependencies].map(&:name).join(', ')}\n"
         say "unique to this (#{stats[:potential_removals].count})   | #{stats[:potential_removals].map(&:name).join(', ')}\n"
+        say ""
+      end
+
+      def draw_versions(stats, target)
+        say "bundle-stats for #{target}"
+        say ""
+        say "depended upon by (#{stats[:top_level_dependencies].count}):\n"
+        say "+------------------------------|-------------------+"
+        say "| Name                         | Required Version  |"
+        say "+------------------------------|-------------------+"
+        stats[:top_level_dependencies].each do |stat_line|
+          say "| %-28s | %-17s |" % [stat_line[:name], stat_line[:version]]
+        end
+        say "+------------------------------|-------------------+"
         say ""
       end
 

--- a/lib/bundler/stats/tree.rb
+++ b/lib/bundler/stats/tree.rb
@@ -21,6 +21,14 @@ class Bundler::Stats::Tree
     }
   end
 
+  def version_requirements(target)
+    transitive_dependencies = transitive_dependencies(target)
+    {
+      name: target,
+      top_level_dependencies: reverse_dependencies_with_versions(target),
+    }
+  end
+
   def first_level_dependencies(target)
     raise ArgumentError, "Unknown gem #{target}" unless @tree.has_key? target
     @tree[target].dependencies
@@ -48,6 +56,21 @@ class Bundler::Stats::Tree
       all_deps = transitive_dependencies(name)
       all_deps.any? { |dep| dep.name == target }
     end
+  end
+
+  def reverse_dependencies_with_versions(target)
+    @tree.map do |name, dep|
+      transitive_dependencies(name).map do |transitive_dependency|
+        if transitive_dependency.name == target
+          {
+            name: dep.name,
+            version: transitive_dependency.requirement.to_s
+          }
+        else
+          nil
+        end
+      end
+    end.flatten.compact
   end
 
   private

--- a/lib/bundler/stats/tree.rb
+++ b/lib/bundler/stats/tree.rb
@@ -22,10 +22,12 @@ class Bundler::Stats::Tree
   end
 
   def version_requirements(target)
-    transitive_dependencies = transitive_dependencies(target)
-    {
-      name: target,
+    transitive_dependencies = transitive_dependencies(target, requirement: true)
+    { name: target,
+      total_dependencies: transitive_dependencies.count,
+      first_level_dependencies: first_level_dependencies(target).count,
       top_level_dependencies: reverse_dependencies_with_versions(target),
+      transitive_dependencies: transitive_dependencies,
     }
   end
 
@@ -64,13 +66,16 @@ class Bundler::Stats::Tree
         if transitive_dependency.name == target
           {
             name: dep.name,
-            version: transitive_dependency.requirement.to_s
+            version: transitive_dependency.requirement.to_s,
+            requirement: transitive_dependency.requirement
           }
         else
           nil
         end
       end
-    end.flatten.compact
+    end.flatten.compact.sort do |a,b|
+      a[:requirement].as_list <=> b[:requirement].as_list
+    end
   end
 
   private

--- a/lib/bundler/stats/tree.rb
+++ b/lib/bundler/stats/tree.rb
@@ -22,7 +22,7 @@ class Bundler::Stats::Tree
   end
 
   def version_requirements(target)
-    transitive_dependencies = transitive_dependencies(target, requirement: true)
+    transitive_dependencies = transitive_dependencies(target)
     { name: target,
       total_dependencies: transitive_dependencies.count,
       first_level_dependencies: first_level_dependencies(target).count,

--- a/spec/lib/bundler/stats/calculator_spec.rb
+++ b/spec/lib/bundler/stats/calculator_spec.rb
@@ -100,4 +100,22 @@ describe Bundler::Stats::Calculator do
       expect(target).to include(:github)
     end
   end
+
+  context "#versions" do
+    it "is a hash" do
+      calculator = subject.new(gemfile_path, lockfile_path)
+      versions = calculator.versions("depth-one")
+
+      expect(versions).to be_a(Hash)
+      expect(versions[:top_level_dependencies]).to eq([])
+    end
+
+    it "returns for second-level deps" do
+      calculator = subject.new(gemfile_path, lockfile_path)
+      versions = calculator.versions("depth-two")
+
+      expect(versions).to be_a(Hash)
+      expect(versions[:top_level_dependencies].map(&:name)).to include("depth-one")
+    end
+  end
 end

--- a/spec/lib/bundler/stats/tree_spec.rb
+++ b/spec/lib/bundler/stats/tree_spec.rb
@@ -124,6 +124,16 @@ describe Bundler::Stats::Tree do
     end
   end
 
+  context "#version_requirements" do
+    it "is a hash with some keys" do
+      tree = subject.new(parser)
+
+      target = tree.version_requirements("depth-one")
+
+      expect(target).to be_a(Hash)
+    end
+  end
+
   context "skip lists" do
     it "still includes the skipped entry" do
       tree = subject.new(parser, skiplist: ["depth-three"])


### PR DESCRIPTION
I've often found myself wonder why bundle update <target> wouldn't do
anything since Bundler sadly doesn't ever explain why it couldn't do
the update. This could be a step toward identifying the version
requirements for each dependent of the target gem in the Gemfile.

For now I don't do any sorting and the results are slightly confusing
because they list all transitive dependencies which have the target in
their own transitive dependency tree.

So if actioncable depends on a gem that depends on nokogiri you will
see actioncable listed as requiring nokogiri (which is technically
correct but slightly confusing).

Example output for `bundle-stats versions nokogiri` in a Rails app:

```
bundle-stats for nokogiri

depended upon by (34):
+------------------------------|-------------------+
| Name                         | Required Version  |
+------------------------------|-------------------+
| actioncable                  | >= 1.6            |
| actionmailer                 | >= 1.6            |
| actionpack                   | >= 1.6            |
| actionview                   | >= 1.6            |
| approvals                    | ~> 1.6            |
| capybara                     | >= 1.3.3          |
| capybara-screenshot          | >= 1.3.3          |
| chromedriver-helper          | ~> 1.6            |
| coercion                     | >= 1.6            |
| coffee-rails                 | >= 1.6            |
| devise                       | >= 1.6            |
| devise-two-factor            | >= 1.6            |
| draper                       | >= 1.6            |
| factory_girl_rails           | >= 1.6            |
| formtastic                   | >= 1.6            |
| google-rails                 | >= 1.6            |
| gretel                       | >= 1.6            |
| haml-rails                   | >= 1.6            |
| html2haml                    | ~> 1.6.0          |
| inline_svg                   | ~> 1.6            |
| loofah                       | >= 1.5.9          |
| prawn_rails                  | >= 1.6            |
| rails                        | >= 1.6            |
| rails-controller-testing     | >= 1.6            |
| rails-dom-testing            | >= 1.6            |
| rails-html-sanitizer         | >= 1.5.9          |
| railties                     | >= 1.6            |
| responders                   | >= 1.6            |
| rspec-rails                  | >= 1.6            |
| sassc-rails                  | >= 1.6            |
| sprockets-rails              | >= 1.6            |
| xpath                        | ~> 1.3            |
+------------------------------|-------------------+
```