### PR TITLE
Skip printing empty dependencies

### DIFF
--- a/lib/bundler/stats/cli.rb
+++ b/lib/bundler/stats/cli.rb
@@ -87,15 +87,17 @@ module Bundler
       def draw_versions(stats, target)
         say "bundle-stats for #{target}"
         say ""
-        say "depended upon by (#{stats[:top_level_dependencies].count}):\n"
-        say "+------------------------------|-------------------+"
-        say "| Name                         | Required Version  |"
-        say "+------------------------------|-------------------+"
-        stats[:top_level_dependencies].each do |stat_line|
-          say "| %-28s | %-17s |" % [stat_line[:name], stat_line[:version]]
+        say "depended upon by (#{stats[:top_level_dependencies].count})\n"
+        if stats[:top_level_dependencies].count > 0
+          say "+------------------------------|-------------------+"
+          say "| Name                         | Required Version  |"
+          say "+------------------------------|-------------------+"
+          stats[:top_level_dependencies].each do |stat_line|
+            say "| %-28s | %-17s |" % [stat_line[:name], stat_line[:version]]
+          end
+          say "+------------------------------|-------------------+"
+          say ""
         end
-        say "+------------------------------|-------------------+"
-        say ""
       end
 
       def build_calculator(options)

--- a/spec/lib/bundler/stats/calculator_spec.rb
+++ b/spec/lib/bundler/stats/calculator_spec.rb
@@ -115,7 +115,7 @@ describe Bundler::Stats::Calculator do
       versions = calculator.versions("depth-two")
 
       expect(versions).to be_a(Hash)
-      expect(versions[:top_level_dependencies].map(&:name)).to include("depth-one")
+      expect(versions[:top_level_dependencies].map { |dep| dep[:name] }).to include("depth-one")
     end
   end
 end


### PR DESCRIPTION
The `bundle-stats versions <gem>` command can skip printing the table of dependencies if it would be empty (no dependencies).

Before:
```
$ bundle-stats versions foo
bundle-stats for foo

depended upon by (0):
+------------------------------|-------------------+
| Name                         | Required Version  |
+------------------------------|-------------------+
+------------------------------|-------------------+
```

After:
```
$ bundle-stats versions foo
bundle-stats for foo

depended upon by (0)
```