### PR TITLE
Fix for "`still_used?': undefined method `dependencies' for nil:NilClass"

### DIFF
--- a/lib/bundler/stats/remover.rb
+++ b/lib/bundler/stats/remover.rb
@@ -26,9 +26,9 @@ module Bundler
         while !deps_to_check.empty? do
           candidate = deps_to_check.pop.name
 
-          next if candidate == deleted
-          next if candidate == "bundler"
+          next if [deleted, "bundler"].include? candidate
           return true if candidate == target
+          next if modified_tree[candidate].nil?
 
           deps_to_check += modified_tree[candidate].dependencies
         end


### PR DESCRIPTION
Hello, my setup is Ruby 2.6.2 and Rails 5.2.3.
I've encountered some errors while using command `bundle-stats versions x` for gems childprocess and tzinfo.

->: `bundle-stats versions childprocess`
```
Traceback (most recent call last):
	12: from /Users/me/.rbenv/versions/2.6.2/bin/bundle-stats:23:in `<main>'
	11: from /Users/me/.rbenv/versions/2.6.2/bin/bundle-stats:23:in `load'
	10: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/bundler-stats-1.3.1/bin/bundle-stats:11:in `<top (required)>'
	 9: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
	 8: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	 7: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	 6: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	 5: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/bundler-stats-1.3.1/lib/bundler/stats/cli.rb:46:in `versions'
	 4: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/bundler-stats-1.3.1/lib/bundler/stats/calculator.rb:34:in `versions'
	 3: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/bundler-stats-1.3.1/lib/bundler/stats/remover.rb:13:in `potential_removals'
	 2: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/bundler-stats-1.3.1/lib/bundler/stats/remover.rb:13:in `reject'
	 1: from /Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/bundler-stats-1.3.1/lib/bundler/stats/remover.rb:14:in `block in potential_removals'
/Users/me/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/bundler-stats-1.3.1/lib/bundler/stats/remover.rb:35:in `still_used?': undefined method `dependencies' for nil:NilClass (NoMethodError)
```

childprocess in Gemfile.lock:
```
    (...)
    selenium-webdriver (3.141.0)
      childprocess (~> 0.5)
    (...)
    childprocess (0.9.0)
```

Sometimes in this line `deps_to_check += modified_tree[candidate].dependencies`, `modified_tree[candidate]` is nil, so it will throw an error. I've added fix to in such cases skip it to next.

After fix:
```
bundle-stats for childprocess

depended upon by (2)
+--------------------|-------------------+
| Name               | Required Version  |
+--------------------|-------------------+
| selenium-webdriver | ~> 0.5            |
| webdrivers         | ~> 0.5            |
+--------------------|-------------------+
```