### PR TITLE
Resolve an issue with trying to remove gems w/ gems from other platforms

### DIFF
--- a/lib/bundler/stats/version.rb
+++ b/lib/bundler/stats/version.rb
@@ -1,6 +1,5 @@
 module Bundler
   module Stats
-    # bundler-stats version
-    VERSION = '1.3.1'
+    VERSION = '1.3.2'
   end
 end

--- a/spec/lib/bundler/stats/remover_spec.rb
+++ b/spec/lib/bundler/stats/remover_spec.rb
@@ -102,5 +102,15 @@ describe Bundler::Stats::Remover do
 
       expect(target).to be_falsy
     end
+
+    it "raises an error if the top level dependency isn't in the lockfile" do
+      top_level << dep("tzinfo")
+      remover = subject.new(tree, top_level)
+      allow(remover).to receive(:warn)
+
+      remover.still_used?("actionview", deleted: "rails")
+
+      expect(remover).to have_received(:warn)
+    end
   end
 end


### PR DESCRIPTION
Co-authored-by: @rwojnarowski

Thanks for finding this issue and creating a reproducible case for me.

When attempting to remove a gem, we check all transitive dependencies
for other folks who depend on our candidate. When we get gems that are
  listed but not present on our current platform this causes a nil.