### PR TITLE
fix issue of logspam now that we're warning of missing lockfile entries

### DIFF
--- a/lib/bundler/stats/remover.rb
+++ b/lib/bundler/stats/remover.rb
@@ -1,11 +1,12 @@
 class Bundler::Stats::Remover
-  ERR_MESSAGE = "Trying to check whether `%s` can be removed, but was unable " \
+  ERR_MESSAGE = "Trying to check whether dep can be removed, but was unable " \
     "to resolve whether it is used by `%s`. It may not be in your Gemfile.lock. " \
     "This often happens when a dependency isn't installed on your platform."
 
   def initialize(tree, top_level)
-    @tree       = tree
-    @top_level  = top_level
+    @tree           = tree
+    @top_level      = top_level
+    @trace_warnings = []
   end
 
   def potential_removals(target)
@@ -33,7 +34,7 @@ class Bundler::Stats::Remover
       return true if candidate == target
 
       if modified_tree[candidate].nil?
-        warn(ERR_MESSAGE % [target, candidate])
+        warn_of_bad_tracing(candidate)
       else
         deps_to_check += modified_tree[candidate].dependencies
       end
@@ -44,7 +45,10 @@ class Bundler::Stats::Remover
 
   private
 
-  def warn(str)
-    STDERR.puts(str)
+  def warn_of_bad_tracing(candidate)
+    return if @trace_warnings.include? candidate
+
+    STDERR.puts(ERR_MESSAGE % [candidate])
+    @trace_warnings << candidate
   end
 end

--- a/lib/bundler/stats/version.rb
+++ b/lib/bundler/stats/version.rb
@@ -1,5 +1,5 @@
 module Bundler
   module Stats
-    VERSION = '1.3.2'
+    VERSION = '1.3.3'
   end
 end

--- a/spec/lib/bundler/stats/remover_spec.rb
+++ b/spec/lib/bundler/stats/remover_spec.rb
@@ -106,11 +106,11 @@ describe Bundler::Stats::Remover do
     it "raises an error if the top level dependency isn't in the lockfile" do
       top_level << dep("tzinfo")
       remover = subject.new(tree, top_level)
-      allow(remover).to receive(:warn)
+      allow(remover).to receive(:warn_of_bad_tracing)
 
       remover.still_used?("actionview", deleted: "rails")
 
-      expect(remover).to have_received(:warn)
+      expect(remover).to have_received(:warn_of_bad_tracing)
     end
   end
 end


### PR DESCRIPTION
asking for removal of anything railsy ends up checking all of the
active* libraries, each of which is checked against tzinfo. but of
course tzinfo is the library we're missing. so, only warn once of the
missing upstream dependency.