### PR TITLE
Drop Travis CI and start using GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        ruby-version: [3.0.x, 2.7.x, 2.6.x, 2.5.x, 2.4.x, 2.3.x]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-script: bundle exec rspec
-rvm:
- - 2.3
- - 2.4
- - 2.5
- - 2.6
- - 2.7
- - 3.0


### PR DESCRIPTION
Hey @jmmastey, 

It seems that CI is not working for the project. 

On June 15th, 2021 travis-ci.org [shutdown](https://blog.travis-ci.com/2021-05-07-orgshutdown). As a result, the CI for this project no longer runs. 

Github offers 2,000 minutes of free build time per month for open source software. Since each build takes less than 1 minute per run, that should be plenty. 

Please let me know what you think.

Thanks! 