### PR TITLE
Rolls back wrong expectation

### DIFF
--- a/spec/lib/bundler/stats/calculator_spec.rb
+++ b/spec/lib/bundler/stats/calculator_spec.rb
@@ -79,11 +79,11 @@ describe Bundler::Stats::Calculator do
   context "#gem_stats" do
     let(:partial_sorted_result) do
       [
-        ["will_paginate", 0],
         ["rolify", 0],
         ["rubocop-rspec", 0],
         ["spring", 0],
         ["state_machine", 0],
+        ["will_paginate", 0]
       ]
     end
 


### PR DESCRIPTION
Hey @jmmastey,

Sorry about this. I had pushed https://github.com/jmmastey/bundler-stats/pull/21/commits/b0a8016b0cd38ae0cb92dfcdada1e761622318f9 just as a way to show that `end_with` compares arrays and cares about lexical sorting. 

This PR removes that PR and corrects the expected result. 

Thanks! 